### PR TITLE
fix code formatting/identation/spaces with astyle, also remove whitespace

### DIFF
--- a/seltag/seltag.c
+++ b/seltag/seltag.c
@@ -16,7 +16,7 @@
 */
 
 struct tag {
-  char buf[40];
+    char buf[40];
 };
 struct tag t[40];
 unsigned int year, mon, day, hour, min, sec;
@@ -34,7 +34,6 @@ struct timeval tv;
  *			       adjtime
  */
 
-
 /* Converts Gregorian date to seconds since 1970-01-01 00:00:00.
  * Assumes input in normal date format, i.e. 1980-12-31 23:59:59
  * => year=1980, mon=12, day=31, hour=23, min=59, sec=59.
@@ -51,151 +50,145 @@ struct timeval tv;
  * will already get problems at other places on 2038-01-19 03:14:08)
  */
 
-unsigned long our_mktime(const unsigned int year0, const unsigned int mon0,
-       const unsigned int day, const unsigned int hour,
-       const unsigned int min, const unsigned int sec)
+unsigned long our_mktime(const unsigned int year0, const unsigned int mon0, const unsigned int day,
+    const unsigned int hour, const unsigned int min, const unsigned int sec)
 {
-	unsigned int mon = mon0, year = year0;
+    unsigned int mon = mon0, year = year0;
 
-	/* 1..12 -> 11,12,1..10 */
-	if (0 >= (int) (mon -= 2)) {
-		mon += 12;	/* Puts Feb last since it has leap day */
-		year -= 1;
-	}
+    /* 1..12 -> 11,12,1..10 */
+    if (0 >= (int)(mon -= 2)) {
+        mon += 12; /* Puts Feb last since it has leap day */
+        year -= 1;
+    }
 
-	return ((((unsigned long)
-		  (year/4 - year/100 + year/400 + 367*mon/12 + day) +
-		  year*365 - 719499
-	    )*24 + hour /* now have hours */
-	  )*60 + min /* now have minutes */
-	)*60 + sec; /* finally seconds */
+    return ((((unsigned long)(year / 4 - year / 100 + year / 400 + 367 * mon / 12 + day) + year * 365 - 719499) * 24
+                + hour /* now have hours */
+                ) * 60
+               + min /* now have minutes */
+               ) * 60
+        + sec; /* finally seconds */
 }
 
-
-int time_parse(char *buf)
+int time_parse(char* buf)
 {
-    int  res = sscanf(buf, 
-		   "%4d-%2d-%2d %2d:%2d:%2d",
-		      &year, &mon, &day, &hour, &min, &sec);
-    
+    int res = sscanf(buf, "%4d-%2d-%2d %2d:%2d:%2d", &year, &mon, &day, &hour, &min, &sec);
+
     return res;
 }
 
 void time_adjust(int offset)
 {
-  struct timeval *tvp;
-  struct tm tm;
-  char tbuf[40];
+    struct timeval* tvp;
+    struct tm tm;
+    char tbuf[40];
 
-  tvp = &tv;
+    tvp = &tv;
 
-  tvp->tv_sec = our_mktime(year, mon, day, hour, min, sec);
-  tvp->tv_usec = 0;
-  tvp->tv_sec += offset;
-  gmtime_r(&tvp->tv_sec, &tm);
+    tvp->tv_sec = our_mktime(year, mon, day, hour, min, sec);
+    tvp->tv_usec = 0;
+    tvp->tv_sec += offset;
+    gmtime_r(&tvp->tv_sec, &tm);
 
-  strftime(tbuf, sizeof(tbuf), "%Y-%m-%d %H:%M:%S", &tm);
-  printf("%s ", tbuf);
+    strftime(tbuf, sizeof(tbuf), "%Y-%m-%d %H:%M:%S", &tm);
+    printf("%s ", tbuf);
 }
 
 void usage(void)
 {
-  printf("\nseltag formats data on stdin by tag to column format on stdout\n");
-  printf("Version %s\n\n", VERSION);
-  printf("Example\n");
-  printf("seltag [-debug ] [-first_field 2] [-time_adjust 0] -sel  ID=%%s T=%%s V_MCU=%%s < infile > outfile\n");
-  printf(" -sel           colums to extract. Format TAG=%%s\n");
-  printf(" -debug\n");
-  printf(" -time_adjust   add or del number Sec\n");
-  //printf(" -first_fields  copied as-is. Time and date.\n");
-  printf("\nExample 1: Extract T\n seltag -sel T=%%s < infile\n");
-  printf("Example 2: Extract V_IN, T, RH\n seltag -sel V_IN=%%s T=%%s RH=%%s < infile\n");
-  printf("Example 3: Extract T, RH and adjust -2Hours\n seltag -time_adjust -7200 -sel T=%%s RH=%%s < infile\n");
+    printf("\nseltag formats data on stdin by tag to column format on stdout\n");
+    printf("Version %s\n\n", VERSION);
+    printf("Example\n");
+    printf("seltag [-debug ] [-first_field 2] [-time_adjust 0] -sel  ID=%%s T=%%s V_MCU=%%s < infile > outfile\n");
+    printf(" -sel           colums to extract. Format TAG=%%s\n");
+    printf(" -debug\n");
+    printf(" -time_adjust   add or del number Sec\n");
+    // printf(" -first_fields  copied as-is. Time and date.\n");
+    printf("\nExample 1: Extract T\n seltag -sel T=%%s < infile\n");
+    printf("Example 2: Extract V_IN, T, RH\n seltag -sel V_IN=%%s T=%%s RH=%%s < infile\n");
+    printf("Example 3: Extract T, RH and adjust -2Hours\n seltag -time_adjust -7200 -sel T=%%s RH=%%s < infile\n");
     exit(-1);
 }
 
-int main(int ac, char *av[]) 
+int main(int ac, char* av[])
 {
-  char buf[BUFSIZ], buf1[BUFSIZ], *res;
-  int i, j, k;
-  int cpy, debug;
-  char timebuf[40];
-  int timeadjust;
-  int selpos;
+    char buf[BUFSIZ], buf1[BUFSIZ], *res;
+    int i, j, k;
+    int cpy, debug;
+    char timebuf[40];
+    int timeadjust;
+    int selpos;
 
-  if (ac == 1 || strcmp(av[1], "-h") == 0) 
-    usage();
+    if (ac == 1 || strcmp(av[1], "-h") == 0)
+        usage();
 
-  debug = 0;
-  cpy = 2;
-  timeadjust = 0;
-  selpos = 0;
+    debug = 0;
+    cpy = 2;
+    timeadjust = 0;
+    selpos = 0;
 
-  for(i = 1; (i < ac) && (av[i][0] == '-'); i++)  {
-    
-    if (strncmp(av[i], "-debug", 6) == 0) {
-      debug = 1;
-    }
-    else if (strncmp(av[i], "-time_adjust", 12) == 0) {
-      timeadjust = atoi(av[++i]);
-    }
-    //else if (strncmp(av[i], "-first_fields", 13) == 0) {
-    //  cpy = atoi(av[++i]);
-    //}
-    else if (strncmp(av[i], "-sel", 4) == 0) {
-      selpos = ++i;
-      break;
-    }
-    else
-      usage();
-  }
-  
-  if(debug) {
-    printf("first_fields=%d\n", cpy);
-    printf("time_adjust=%d\n", timeadjust);
-    printf("sel_pos=%d\n", selpos);
-  }
-  
-  if(selpos == 0) {
-    printf("\nError. You must give -sel followed by selection criterias\n\n");
-    usage();
-  }
+    for (i = 1; (i < ac) && (av[i][0] == '-'); i++) {
 
-    while ( fgets ( buf, BUFSIZ, stdin ) != NULL ) {
-    res = strtok( buf, " " );
-
-    for(k = selpos; k < ac; k++) 
-      strcpy( t[k].buf, "Miss");
-
-    timebuf[0] = 0;
-    for(i = 0;  res != NULL; i++ ) {
-
-      if(i < cpy) {
-      	strcat(timebuf, res);
-	strcat(timebuf, " ");
-       }
-
-      for(k = selpos; k < ac; k++) {
-	j = sscanf(res, av[k], buf1);   
-	if(j) 
-	  strcpy( t[k].buf, buf1);
-      } /* for */
-
-      res = strtok( NULL, " " );
+        if (strncmp(av[i], "-debug", 6) == 0) {
+            debug = 1;
+        }
+        else if (strncmp(av[i], "-time_adjust", 12) == 0) {
+            timeadjust = atoi(av[++i]);
+        }
+        // else if (strncmp(av[i], "-first_fields", 13) == 0) {
+        //  cpy = atoi(av[++i]);
+        //}
+        else if (strncmp(av[i], "-sel", 4) == 0) {
+            selpos = ++i;
+            break;
+        }
+        else
+            usage();
     }
 
-    time_parse(timebuf);
+    if (debug) {
+        printf("first_fields=%d\n", cpy);
+        printf("time_adjust=%d\n", timeadjust);
+        printf("sel_pos=%d\n", selpos);
+    }
 
-    if(timeadjust) 
-      time_adjust(timeadjust);
-    else
-      printf("%04u-%02u-%02u %02u:%02u:%02u ",
-    		      year, mon, day, hour, min, sec);
+    if (selpos == 0) {
+        printf("\nError. You must give -sel followed by selection criterias\n\n");
+        usage();
+    }
 
-    for(k = 2; k < ac; k++) 
-      printf("%s ", t[k].buf);
-    printf("\n");
+    while (fgets(buf, BUFSIZ, stdin) != NULL) {
+        res = strtok(buf, " ");
 
-  }
-  exit(0);
+        for (k = selpos; k < ac; k++)
+            strcpy(t[k].buf, "Miss");
+
+        timebuf[0] = 0;
+        for (i = 0; res != NULL; i++) {
+
+            if (i < cpy) {
+                strcat(timebuf, res);
+                strcat(timebuf, " ");
+            }
+
+            for (k = selpos; k < ac; k++) {
+                j = sscanf(res, av[k], buf1);
+                if (j)
+                    strcpy(t[k].buf, buf1);
+            } /* for */
+
+            res = strtok(NULL, " ");
+        }
+
+        time_parse(timebuf);
+
+        if (timeadjust)
+            time_adjust(timeadjust);
+        else
+            printf("%04u-%02u-%02u %02u:%02u:%02u ", year, mon, day, hour, min, sec);
+
+        for (k = 2; k < ac; k++)
+            printf("%s ", t[k].buf);
+        printf("\n");
+    }
+    exit(0);
 }

--- a/sensd/devtag-allinone.c
+++ b/sensd/devtag-allinone.c
@@ -26,220 +26,226 @@
 #include "libdevtag.h"
 #endif
 
-static int usb_scan_dir(struct dev_head *result, const struct devinfo_head *sel, const char *dir);
+static int usb_scan_dir(struct dev_head* result, const struct devinfo_head* sel, const char* dir);
 
-static char *getstring(const char *dir, const char *file)
+static char* getstring(const char* dir, const char* file)
 {
-	char fn[512];
-	char buf[256];
-	int fd, n;
-	
-	sprintf(fn, "%s/%s", dir, file);
-	fd = open(fn, O_RDONLY);
-	if(fd == -1) return NULL;
+    char fn[512];
+    char buf[256];
+    int fd, n;
 
-	n = read(fd, buf, sizeof(buf)-1);
-	if(n >= 0) {
-		buf[n] = 0;
-		if(n > 0) {
-			if(buf[n-1] == '\n')
-				buf[n-1] = 0;
-		}
-	} else buf[0] = 0;
-	buf[sizeof(buf)-1] = 0;
-	close(fd);
-	return strdup(buf);
+    sprintf(fn, "%s/%s", dir, file);
+    fd = open(fn, O_RDONLY);
+    if (fd == -1)
+        return NULL;
+
+    n = read(fd, buf, sizeof(buf) - 1);
+    if (n >= 0) {
+        buf[n] = 0;
+        if (n > 0) {
+            if (buf[n - 1] == '\n')
+                buf[n - 1] = 0;
+        }
+    }
+    else
+        buf[0] = 0;
+    buf[sizeof(buf) - 1] = 0;
+    close(fd);
+    return strdup(buf);
 }
 
 /*
  * scan usb devices.
  * add matching devices to result list
  */
-int devtag_usb_scan(struct dev_head *result, const struct devinfo_head *sel)
+int devtag_usb_scan(struct dev_head* result, const struct devinfo_head* sel)
 {
-	return usb_scan_dir(result, sel, "/sys/bus/usb/devices");
+    return usb_scan_dir(result, sel, "/sys/bus/usb/devices");
 }
 
-static char *dev_probe(const char *name)
+static char* dev_probe(const char* name)
 {
-	char fn[512];
-	struct stat statb;
+    char fn[512];
+    struct stat statb;
 
-	sprintf(fn, "/dev/%s", name);
-	if(stat(fn, &statb)==0) {
-		if(S_ISBLK(statb.st_mode))
-			return "b";
-		if(S_ISCHR(statb.st_mode))
-			return "c";
-	}
-	return "f";
+    sprintf(fn, "/dev/%s", name);
+    if (stat(fn, &statb) == 0) {
+        if (S_ISBLK(statb.st_mode))
+            return "b";
+        if (S_ISCHR(statb.st_mode))
+            return "c";
+    }
+    return "f";
 }
 
-static struct devname *devname_new(const char *dir)
+static struct devname* devname_new(const char* dir)
 {
-	struct devname *dn;
-	char *name;
+    struct devname* dn;
+    char* name;
 
-	name = basename(strdup(dir));
-	if(isdigit(name[0]) )
-		return NULL;
-	
-	dn = malloc(sizeof(struct devname));
-	dn->dev = getstring(dir, "dev");
-	dn->devname = name;
-	dn->type = dev_probe(name);
-	dn->pos = strlen(dir);
-	dn->next = NULL;
-//	printf("devname_new %s %s %s\n", dn->dev, dn->devname, dir);
-	return dn;
+    name = basename(strdup(dir));
+    if (isdigit(name[0]))
+        return NULL;
+
+    dn = malloc(sizeof(struct devname));
+    dn->dev = getstring(dir, "dev");
+    dn->devname = name;
+    dn->type = dev_probe(name);
+    dn->pos = strlen(dir);
+    dn->next = NULL;
+    //	printf("devname_new %s %s %s\n", dn->dev, dn->devname, dir);
+    return dn;
 }
 
 /*
  * depth-first scan for all dev files. name of parentdir is assumed to be node name.
  */
-static int usb_scan_devname(const char *dir, struct devname_head *devnames)
+static int usb_scan_devname(const char* dir, struct devname_head* devnames)
 {
-	DIR *d;
-	struct dirent *ent;
-	char fn[512];
-	int len;
-	
-//	printf("scan_devname opening dir %s\n", dir);
-	d = opendir(dir);
-	if(!d) return 0;
-	
-	while((ent = readdir(d))) {
-		if(ent->d_type == DT_LNK) continue;
-		if(ent->d_type == DT_UNKNOWN) {
-			/* FIXME: use lstat to determine if file is a link */
-			printf("DT_UNKNOWN\n");
-			exit(1);
-		}
-		if(ent->d_name[0] != '.') {
-			sprintf(fn, "%s/%s", dir, ent->d_name);
-			usb_scan_devname(fn, devnames);
-		}
-		if(!strcmp(ent->d_name, "dev")) {
-			struct devname *devname;
-			devname = devname_new(dir);
-			if(devname) {
-				devname->next = devnames->head;
-				devnames->head = devname;
-			}
-		}
-	}
-	closedir(d);
-	
-	{
-		struct devname *dn;
-		len=0;
-		for(dn=devnames->head;dn;dn=dn->next)
-			len++;
-	}
-	return len;
+    DIR* d;
+    struct dirent* ent;
+    char fn[512];
+    int len;
+
+    //	printf("scan_devname opening dir %s\n", dir);
+    d = opendir(dir);
+    if (!d)
+        return 0;
+
+    while ((ent = readdir(d))) {
+        if (ent->d_type == DT_LNK)
+            continue;
+        if (ent->d_type == DT_UNKNOWN) {
+            /* FIXME: use lstat to determine if file is a link */
+            printf("DT_UNKNOWN\n");
+            exit(1);
+        }
+        if (ent->d_name[0] != '.') {
+            sprintf(fn, "%s/%s", dir, ent->d_name);
+            usb_scan_devname(fn, devnames);
+        }
+        if (!strcmp(ent->d_name, "dev")) {
+            struct devname* devname;
+            devname = devname_new(dir);
+            if (devname) {
+                devname->next = devnames->head;
+                devnames->head = devname;
+            }
+        }
+    }
+    closedir(d);
+
+    {
+        struct devname* dn;
+        len = 0;
+        for (dn = devnames->head; dn; dn = dn->next)
+            len++;
+    }
+    return len;
 }
 
-static int dev_info_add(struct dev *dev, const char *dir, const char *name)
+static int dev_info_add(struct dev* dev, const char* dir, const char* name)
 {
-	struct devinfo *info;
-	char *value;
-	
-	value = getstring(dir, name);
-	
-	if(value) {
-		info = malloc(sizeof(struct devinfo));
-		info->name = name;
-		info->value = value;
-	
-		info->next = dev->info.head;
-		dev->info.head = info;
-		return 0;
-	}
-	return -1;
+    struct devinfo* info;
+    char* value;
+
+    value = getstring(dir, name);
+
+    if (value) {
+        info = malloc(sizeof(struct devinfo));
+        info->name = name;
+        info->value = value;
+
+        info->next = dev->info.head;
+        dev->info.head = info;
+        return 0;
+    }
+    return -1;
 }
 
-static struct dev *dev_new()
+static struct dev* dev_new()
 {
-	struct dev *d;
-	d = malloc(sizeof(struct dev));
-	d->class = "usb";
-	d->next = NULL;
-	return d;
+    struct dev* d;
+    d = malloc(sizeof(struct dev));
+    d->class = "usb";
+    d->next = NULL;
+    return d;
 }
 
-static int usb_dev_match(const struct devinfo_head *info, const struct devinfo_head *selectors)
+static int usb_dev_match(const struct devinfo_head* info, const struct devinfo_head* selectors)
 {
-	int match=1;
-	struct devinfo *sel, *i;
-	
-	for(sel=selectors->head;sel;sel=sel->next) {
-		match=0;
-		for(i=info->head;i;i=i->next) {
-			if(strcmp(i->name, sel->name)==0) {
-				if(fnmatch(sel->value, i->value, 0)==0) {
-					match=1;
-					break;
-				}
-			}
-		}
-		if(match==0)
-			return 0;
-	}
-	return match;
+    int match = 1;
+    struct devinfo* sel, *i;
+
+    for (sel = selectors->head; sel; sel = sel->next) {
+        match = 0;
+        for (i = info->head; i; i = i->next) {
+            if (strcmp(i->name, sel->name) == 0) {
+                if (fnmatch(sel->value, i->value, 0) == 0) {
+                    match = 1;
+                    break;
+                }
+            }
+        }
+        if (match == 0)
+            return 0;
+    }
+    return match;
 }
 
-static int usb_scan_dev(struct dev_head *result, const struct devinfo_head *sel, const char *dir)
+static int usb_scan_dev(struct dev_head* result, const struct devinfo_head* sel, const char* dir)
 {
-	char *usbdev;
-	struct devname_head devnames;
-	struct dev *dev;
-	
-	usbdev = getstring(dir, "dev");
-	if(usbdev) {
-		devnames.head = NULL;
-		
-		if(usb_scan_devname(dir, &devnames)) {
-			dev = dev_new();
-			dev->devnames.head = devnames.head;
-			dev->info.head = NULL;
-			dev_info_add(dev, dir, "serial");
-			dev_info_add(dev, dir, "manufacturer");
-			dev_info_add(dev, dir, "product");
-			dev_info_add(dev, dir, "idProduct");
-			dev_info_add(dev, dir, "idVendor");
+    char* usbdev;
+    struct devname_head devnames;
+    struct dev* dev;
 
-			if(usb_dev_match(&dev->info, sel)) {
-				dev->next = result->head;
-				result->head = dev;
-			}
-		}
-	}
-	return 0;
+    usbdev = getstring(dir, "dev");
+    if (usbdev) {
+        devnames.head = NULL;
+
+        if (usb_scan_devname(dir, &devnames)) {
+            dev = dev_new();
+            dev->devnames.head = devnames.head;
+            dev->info.head = NULL;
+            dev_info_add(dev, dir, "serial");
+            dev_info_add(dev, dir, "manufacturer");
+            dev_info_add(dev, dir, "product");
+            dev_info_add(dev, dir, "idProduct");
+            dev_info_add(dev, dir, "idVendor");
+
+            if (usb_dev_match(&dev->info, sel)) {
+                dev->next = result->head;
+                result->head = dev;
+            }
+        }
+    }
+    return 0;
 }
 
-static int usb_scan_dir(struct dev_head *result, const struct devinfo_head *sel, const char *dir)
+static int usb_scan_dir(struct dev_head* result, const struct devinfo_head* sel, const char* dir)
 {
-	DIR *d;
-	struct dirent *ent;
-	char fn[512];
-	
-/*
- /sys/bus/usb/devices/usb1/1-4/serial
- /sys/bus/usb/devices/1-4:1.0/serial
+    DIR* d;
+    struct dirent* ent;
+    char fn[512];
 
- */
-//	printf("opening dir %s\n", dir);
-	d = opendir(dir);
-	if(!d) return 0;
+    /*
+     /sys/bus/usb/devices/usb1/1-4/serial
+     /sys/bus/usb/devices/1-4:1.0/serial
 
-	while((ent = readdir(d))) {
-		if(ent->d_name[0] != '.') {
-			sprintf(fn, "%s/%s", dir, ent->d_name);
-			usb_scan_dev(result, sel, fn);
-		}
-	}
-	closedir(d);
-	return 0;
+     */
+    //	printf("opening dir %s\n", dir);
+    d = opendir(dir);
+    if (!d)
+        return 0;
+
+    while ((ent = readdir(d))) {
+        if (ent->d_name[0] != '.') {
+            sprintf(fn, "%s/%s", dir, ent->d_name);
+            usb_scan_dev(result, sel, fn);
+        }
+    }
+    closedir(d);
+    return 0;
 }
 /*
  * File: dev.c
@@ -256,10 +262,7 @@ static int usb_scan_dir(struct dev_head *result, const struct devinfo_head *sel,
 #include "libdevtag.h"
 #endif
 
-int devtag_dev_scan(struct dev_head *result, const struct devinfo_head *sel)
-{
-	return devtag_usb_scan(result,sel);
-}
+int devtag_dev_scan(struct dev_head* result, const struct devinfo_head* sel) { return devtag_usb_scan(result, sel); }
 /*
  * File: lookup.c
  * Implements: device name lookup functions
@@ -285,162 +288,165 @@ int devtag_dev_scan(struct dev_head *result, const struct devinfo_head *sel)
 #include "libdevtag.h"
 #endif
 
-static int parse(const char *devname, char **class, char **devpattern, char **constdev, struct devinfo_head *sel)
+static int parse(const char* devname, char** class, char** devpattern, char** constdev, struct devinfo_head* sel)
 {
-	char *home, *pp, *p, *name, *value, fn[256], buf[512];
-	int fd;
-	ssize_t n;
-	struct devinfo *di;
-	
-	*class = NULL;
-	*devpattern = NULL;
-	*constdev = NULL;
-	
-	sprintf(fn, "/etc/devtag.d/%s.conf", devname);
-	fd = open(fn, O_RDONLY);
-	if(fd == -1) {
-		home = getenv("HOME");
-		if(home) {
-			sprintf(fn, "%s/.devtag.d/%s.conf", home, devname);
-			fd = open(fn, O_RDONLY);
-		}
-	}
-	if(fd == -1) return -1;
-	
-	n = read(fd, buf, sizeof(buf)-1);
-	if(n <= 0)
-		return -2;
-	
-	buf[n] = 0;
+    char* home, *pp, *p, *name, *value, fn[256], buf[512];
+    int fd;
+    ssize_t n;
+    struct devinfo* di;
 
-	p = buf;
-	while(p && *p) {
-		name = p;
-		p = strchr(p, '\n');
-		if(p) {
-			*p = 0;
-			p++;
-		}
-		value = strchr(name, '=');
-		if(value) {
-			*value = 0;
-			value++;
-			if(*value == '"') {
-				value++;
-				pp = strchr(value, '"');
-				if(pp) *pp = 0;
-			}
-			
-			if(!strcmp(name, "class")) {
-				*class = strdup(value);
-				continue;
-			}
-			if(!strcmp(name, "dev")) {
-				*devpattern = strdup(value);
-				continue;
-			}
-			if(!strcmp(name, "devname")) {
-				*constdev = strdup(value);
-				continue;
-			}
-			
-			di = malloc(sizeof(struct devinfo));
-			if(di) {
-				di->name = strdup(name);
-				di->value = strdup(value);
-				di->next = sel->head;
-				sel->head = di;
-			}
-		}
-	}
+    *class = NULL;
+    *devpattern = NULL;
+    *constdev = NULL;
 
-	close(fd);
-	return 0;
+    sprintf(fn, "/etc/devtag.d/%s.conf", devname);
+    fd = open(fn, O_RDONLY);
+    if (fd == -1) {
+        home = getenv("HOME");
+        if (home) {
+            sprintf(fn, "%s/.devtag.d/%s.conf", home, devname);
+            fd = open(fn, O_RDONLY);
+        }
+    }
+    if (fd == -1)
+        return -1;
+
+    n = read(fd, buf, sizeof(buf) - 1);
+    if (n <= 0)
+        return -2;
+
+    buf[n] = 0;
+
+    p = buf;
+    while (p && *p) {
+        name = p;
+        p = strchr(p, '\n');
+        if (p) {
+            *p = 0;
+            p++;
+        }
+        value = strchr(name, '=');
+        if (value) {
+            *value = 0;
+            value++;
+            if (*value == '"') {
+                value++;
+                pp = strchr(value, '"');
+                if (pp)
+                    *pp = 0;
+            }
+
+            if (!strcmp(name, "class")) {
+                *class = strdup(value);
+                continue;
+            }
+            if (!strcmp(name, "dev")) {
+                *devpattern = strdup(value);
+                continue;
+            }
+            if (!strcmp(name, "devname")) {
+                *constdev = strdup(value);
+                continue;
+            }
+
+            di = malloc(sizeof(struct devinfo));
+            if (di) {
+                di->name = strdup(name);
+                di->value = strdup(value);
+                di->next = sel->head;
+                sel->head = di;
+            }
+        }
+    }
+
+    close(fd);
+    return 0;
 }
 
-static char *dev_match(struct dev *dev, char *devpattern)
+static char* dev_match(struct dev* dev, char* devpattern)
 {
-	struct devname *devname;
-	
-	for(devname=dev->devnames.head;devname;devname=devname->next) {
-		if(fnmatch(devpattern, devname->devname, 0)==0) {
-			return devname->devname;
-		}
-	}
-	return NULL;
+    struct devname* devname;
+
+    for (devname = dev->devnames.head; devname; devname = devname->next) {
+        if (fnmatch(devpattern, devname->devname, 0) == 0) {
+            return devname->devname;
+        }
+    }
+    return NULL;
 }
 
-int devtag_lookup2(char *buf, size_t bufsize, char *constbuf, size_t constsize, const char *devname)
+int devtag_lookup2(char* buf, size_t bufsize, char* constbuf, size_t constsize, const char* devname)
 {
-	struct devinfo_head sel;
-	struct dev_head result;
-	struct dev *dev;
-	char *class, *devpattern, *constdev, *pfx="";
-	struct devname *dn;
-	int len = 0;
-	
-	sel.head = NULL;
-	result.head = NULL;
-	
-	snprintf(buf, bufsize, "%s", devname);
-	
-	if(strncmp(devname, "/dev/", 5)==0) {
-		pfx = "/dev/";
-		devname += 5;
-	}
+    struct devinfo_head sel;
+    struct dev_head result;
+    struct dev* dev;
+    char* class, *devpattern, *constdev, * pfx = "";
+    struct devname* dn;
+    int len = 0;
 
-	/* parse config file in /etc/devtag.d/ */
-	if(parse(devname, &class, &devpattern, &constdev, &sel))
-		return -1;
-	if(constbuf) {
-		constbuf[0] = 0;
-		if(constdev)
-			strncpy(constbuf, constdev, constsize-1);
-		constbuf[constsize-1] = 0;
-	}
-	
-	if(!class) class = "usb";
+    sel.head = NULL;
+    result.head = NULL;
 
-	/* look for usb devices */
-	if(strcmp(class, "usb")==0)
-		devtag_usb_scan(&result, &sel);
+    snprintf(buf, bufsize, "%s", devname);
 
-	for(dev=result.head;dev;dev=dev->next) {
-		len++;
-	}
+    if (strncmp(devname, "/dev/", 5) == 0) {
+        pfx = "/dev/";
+        devname += 5;
+    }
 
-	if(!devpattern) {
-		dev = result.head;
-		if(dev) {
-			dn = dev->devnames.head;
-			if(dn) {
-				snprintf(buf, bufsize, "%s%s", pfx, dn->devname);
-				return len;
-			}
-		}
-	}
+    /* parse config file in /etc/devtag.d/ */
+    if (parse(devname, &class, &devpattern, &constdev, &sel))
+        return -1;
+    if (constbuf) {
+        constbuf[0] = 0;
+        if (constdev)
+            strncpy(constbuf, constdev, constsize - 1);
+        constbuf[constsize - 1] = 0;
+    }
 
-	/* check for matching device node with devpattern among the devices that matched
-	   selectors */
-	for(dev=result.head;dev;dev=dev->next) {
-		/* find any matching devicenode */
-		if((devname = dev_match(dev, devpattern))) {
-			snprintf(buf, bufsize, "%s%s", pfx, devname);
-			return len;
-		}
-	}
-	return 0;
+    if (!class)
+        class = "usb";
+
+    /* look for usb devices */
+    if (strcmp(class, "usb") == 0)
+        devtag_usb_scan(&result, &sel);
+
+    for (dev = result.head; dev; dev = dev->next) {
+        len++;
+    }
+
+    if (!devpattern) {
+        dev = result.head;
+        if (dev) {
+            dn = dev->devnames.head;
+            if (dn) {
+                snprintf(buf, bufsize, "%s%s", pfx, dn->devname);
+                return len;
+            }
+        }
+    }
+
+    /* check for matching device node with devpattern among the devices that matched
+       selectors */
+    for (dev = result.head; dev; dev = dev->next) {
+        /* find any matching devicenode */
+        if ((devname = dev_match(dev, devpattern))) {
+            snprintf(buf, bufsize, "%s%s", pfx, devname);
+            return len;
+        }
+    }
+    return 0;
 }
 
-int devtag_lookup(char *buf, size_t bufsize, const char *devname)
+int devtag_lookup(char* buf, size_t bufsize, const char* devname)
 {
-	return devtag_lookup2(buf, bufsize, NULL, 0, devname);
+    return devtag_lookup2(buf, bufsize, NULL, 0, devname);
 }
 
-char *devtag_get(const char *devname)
+char* devtag_get(const char* devname)
 {
-	char buf[64];
-	buf[0] = 0;
-	devtag_lookup(buf, sizeof(buf), devname);
-	return strdup(buf);
+    char buf[64];
+    buf[0] = 0;
+    devtag_lookup(buf, sizeof(buf), devname);
+    return strdup(buf);
 }

--- a/sensd/devtag-allinone.h
+++ b/sensd/devtag-allinone.h
@@ -12,17 +12,17 @@
  *
  * Returns number of devices found or a negative value if an error occured.
  */
-int devtag_lookup(char *buf, size_t bufsize, const char *devtag);
+int devtag_lookup(char* buf, size_t bufsize, const char* devtag);
 
 /* also returns a constant name if supplied in the configuration */
-int devtag_lookup2(char *buf, size_t bufsize, char *constbuf, size_t constsize, const char *devtag);
+int devtag_lookup2(char* buf, size_t bufsize, char* constbuf, size_t constsize, const char* devtag);
 
 /*
  * Simple lookup.
  * Returns a suitable replacement for devtag.
  * If no replacement can be determined a 'devtag' will be returned as a duplicated string.
  */
-char *devtag_get(const char *devtag);
+char* devtag_get(const char* devtag);
 
 #endif
 #ifndef LIBDEVTAG_H
@@ -32,51 +32,50 @@ char *devtag_get(const char *devtag);
 
 struct devname;
 struct devname_head {
-  struct devname *head;
+    struct devname* head;
 };
 
 struct devname {
-  char *dev;
-  char *devname;
-  char *type;
-  int pos;
-  struct devname *next;
+    char* dev;
+    char* devname;
+    char* type;
+    int pos;
+    struct devname* next;
 };
 
 struct devinfo;
 struct devinfo_head {
-  struct devinfo *head;
+    struct devinfo* head;
 };
 
 struct devinfo {
-  const char *name;
-  const char *value;
-  struct devinfo *next;
+    const char* name;
+    const char* value;
+    struct devinfo* next;
 };
 
 struct dev;
 struct dev_head {
-  struct dev *head;
+    struct dev* head;
 };
 
 struct dev {
-  struct devinfo_head info;
-  struct devname_head devnames;
-  char *class; /* "usb", "pci" etc */
-  struct dev *next;
+    struct devinfo_head info;
+    struct devname_head devnames;
+    char* class; /* "usb", "pci" etc */
+    struct dev* next;
 };
 
 /*
  * Find devices matching selections in list 'sel' (of type struct dev_info).
  * Put matching devices in result list 'result'.
  */
-int devtag_dev_scan(struct dev_head *result, const struct devinfo_head *sel);
+int devtag_dev_scan(struct dev_head* result, const struct devinfo_head* sel);
 
 /*
  * Find USB devices matching selections in list 'sel' (of type struct dev_info).
  * Put matching USB devices in result list 'result'.
  */
-int devtag_usb_scan(struct dev_head *result, const struct devinfo_head *sel);
-
+int devtag_usb_scan(struct dev_head* result, const struct devinfo_head* sel);
 
 #endif

--- a/sensd/sensd.c
+++ b/sensd/sensd.c
@@ -1,6 +1,6 @@
 /*
  Copyright GPL by
- Robert Olsson  <robert@Radio-Sensors.COM>  
+ Robert Olsson  <robert@Radio-Sensors.COM>
 
  Code used from:
 
@@ -44,7 +44,7 @@
 
 #define VERSION "5.5 2015-04-11"
 #define END_OF_FILE 26
-#define CTRLD  4
+#define CTRLD 4
 #define P_LOCK "/var/lock"
 #define LOGFILE "/var/log/sensors.dat"
 
@@ -54,24 +54,24 @@ char username[16];
 int pid;
 int retry = 6;
 
-float *gps_lon, *gps_lat;
-char *domain = NULL;
+float* gps_lon, *gps_lat;
+char* domain = NULL;
 
 int debug = 0;
 
 #define BUFSIZE 1024
-#define SERVER_PORT  1234
-#define SEND_PORT  SERVER_PORT  
+#define SERVER_PORT 1234
+#define SEND_PORT SERVER_PORT
 
-#define TRUE             1
-#define FALSE            0
-
+#define TRUE 1
+#define FALSE 0
 
 void usage(void)
 {
   printf("\nVersion %s\n", VERSION);
   printf("\nsensd: A WSN gateway, proxy and hub\n");
-  printf("Usage: sensd [-send addr] [-send_port port] [-p port] [-report] [-domain dmn] [-utc] [-f file] [-R path] [-g gpsdev] [-LATY.xx] [-LONY.yy] [ -D dev]\n");
+  printf("Usage: sensd [-send addr] [-send_port port] [-p port] [-report] [-domain dmn] [-utc] [-f file] [-R path] "
+         "[-g gpsdev] [-LATY.xx] [-LONY.yy] [ -D dev]\n");
 
   printf(" -D dev       Serial or USB dev. Typically /dev/ttyUSB0\n");
   printf(" -f file      Local logfile. Default is %s\n", LOGFILE);
@@ -98,9 +98,8 @@ void usage(void)
   exit(-1);
 }
 
-
 /* Function declarations */
-int gps_read(int fd, float *lon, float *lat);
+int gps_read(int fd, float* lon, float* lat);
 
 /* Options*/
 int cmd, date, utime, utc, background;
@@ -113,25 +112,28 @@ double lon = GPS_MISS, lat = GPS_MISS;
  * Find out name to use for lockfile when locking tty.
  */
 
-char *mbasename(char *s, char *res, int reslen)
+char* mbasename(char* s, char* res, int reslen)
 {
-  char *p;
-  
-  if (strncmp(s, "/dev/", 5) == 0) {
+  char* p;
+
+  if (strncmp(s, "/dev/", 5) == 0)
+  {
     /* In /dev */
     strncpy(res, s + 5, reslen - 1);
-    res[reslen-1] = 0;
+    res[reslen - 1] = 0;
     for (p = res; *p; p++)
       if (*p == '/')
         *p = '_';
-  } else {
+  }
+  else
+  {
     /* Outside of /dev. Do something sensible. */
     if ((p = strrchr(s, '/')) == NULL)
       p = s;
     else
       p++;
     strncpy(res, p, reslen - 1);
-    res[reslen-1] = 0;
+    res[reslen - 1] = 0;
   }
   return res;
 }
@@ -143,11 +145,13 @@ int lockfile_create(void)
 
   n = umask(022);
   /* Create lockfile compatible with UUCP-1.2  and minicom */
-  if ((fd = open(lockfile, O_WRONLY | O_CREAT | O_EXCL, 0666)) < 0) {
+  if ((fd = open(lockfile, O_WRONLY | O_CREAT | O_EXCL, 0666)) < 0)
+  {
     return 0;
-  } else {
-    snprintf(buf, sizeof(buf),  "%05d sensd %.20s\n", (int) getpid(), 
-	     username);
+  }
+  else
+  {
+    snprintf(buf, sizeof(buf), "%05d sensd %.20s\n", (int)getpid(), username);
 
     write(fd, buf, strlen(buf));
     close(fd);
@@ -164,18 +168,18 @@ void lockfile_remove(void)
 
 int have_lock_dir(void)
 {
- struct stat stt;
+  struct stat stt;
   char buf[128];
 
-  if ( stat(P_LOCK, &stt) == 0) {
+  if (stat(P_LOCK, &stt) == 0)
+  {
 
-    snprintf(lockfile, sizeof(lockfile),
-                       "%s/LCK..%s",
-                       P_LOCK, mbasename(dial_tty, buf, sizeof(buf)));
+    snprintf(lockfile, sizeof(lockfile), "%s/LCK..%s", P_LOCK, mbasename(dial_tty, buf, sizeof(buf)));
   }
-  else {
-	  fprintf(stderr, "Lock directory %s does not exist\n", P_LOCK);
-	exit(-1);
+  else
+  {
+    fprintf(stderr, "Lock directory %s does not exist\n", P_LOCK);
+    exit(-1);
   }
   return 1;
 }
@@ -187,30 +191,35 @@ int get_lock()
 
   have_lock_dir();
 
-  if((fd = open(lockfile, O_RDONLY)) >= 0) {
+  if ((fd = open(lockfile, O_RDONLY)) >= 0)
+  {
     n = read(fd, buf, 127);
     close(fd);
-    if (n > 0) {
+    if (n > 0)
+    {
       pid = -1;
       if (n == 4)
         /* Kermit-style lockfile. */
-        pid = *(int *)buf;
-      else {
+        pid = *(int*)buf;
+      else
+      {
         /* Ascii lockfile. */
         buf[n] = 0;
         sscanf(buf, "%d", &pid);
       }
-      if (pid > 0 && kill((pid_t)pid, 0) < 0 &&
-          errno == ESRCH) {
-	      fprintf(stderr, "Lockfile is stale. Overriding it..\n");
+      if (pid > 0 && kill((pid_t)pid, 0) < 0 && errno == ESRCH)
+      {
+        fprintf(stderr, "Lockfile is stale. Overriding it..\n");
         sleep(1);
         unlink(lockfile);
-      } else
+      }
+      else
         n = 0;
     }
-    if (n == 0) {
-      if(retry == 1) /* Last retry */
-	      fprintf(stderr, "Device %s is locked.\n", dial_tty);
+    if (n == 0)
+    {
+      if (retry == 1) /* Last retry */
+        fprintf(stderr, "Device %s is locked.\n", dial_tty);
       return 0;
     }
   }
@@ -218,57 +227,57 @@ int get_lock()
   return 1;
 }
 
-void print_report_time(char *ibuf)
+void print_report_time(char* ibuf)
 {
   time_t raw_time;
-  struct tm *tp;
+  struct tm* tp;
   char buf[256];
 
-  time ( &raw_time );
+  time(&raw_time);
 
-  if(utc)
-    tp = gmtime ( &raw_time );
+  if (utc)
+    tp = gmtime(&raw_time);
   else
-    tp = localtime ( &raw_time );
+    tp = localtime(&raw_time);
 
-  if(date) {
-	  sprintf(buf, "%04d-%02d-%02d %02d:%02d:%02d TZ=%s ",
-		  tp->tm_year+1900, tp->tm_mon+1, 
-		  tp->tm_mday, tp->tm_hour, 
-		  tp->tm_min, tp->tm_sec, tp->tm_zone);
+  if (date)
+  {
+    sprintf(buf, "%04d-%02d-%02d %02d:%02d:%02d TZ=%s ", tp->tm_year + 1900, tp->tm_mon + 1, tp->tm_mday,
+            tp->tm_hour, tp->tm_min, tp->tm_sec, tp->tm_zone);
   }
   memcpy(ibuf, buf, strlen(buf));
 }
 
-void print_report_header(char *gpsdev, char *datebuf)
+void print_report_header(char* gpsdev, char* datebuf)
 {
   time_t raw_time;
-  struct tm *tp;
+  struct tm* tp;
   char buf[256];
 
   *datebuf = 0;
 
-  time ( &raw_time );
+  time(&raw_time);
 
-  if(utc)
-    tp = gmtime ( &raw_time );
+  if (utc)
+    tp = gmtime(&raw_time);
   else
-    tp = localtime ( &raw_time );
+    tp = localtime(&raw_time);
 
-  if(date) {
-	  sprintf(buf, "%04d-%02d-%02d %02d:%02d:%02d TZ=%s ",
-		  tp->tm_year+1900, tp->tm_mon+1, 
-		  tp->tm_mday, tp->tm_hour, 
-		  tp->tm_min, tp->tm_sec, tp->tm_zone);
-	  strcat(datebuf, buf);
+  if (date)
+  {
+    sprintf(buf, "%04d-%02d-%02d %02d:%02d:%02d TZ=%s ", tp->tm_year + 1900, tp->tm_mon + 1, tp->tm_mday,
+            tp->tm_hour, tp->tm_min, tp->tm_sec, tp->tm_zone);
+    strcat(datebuf, buf);
   }
 
-  if(utime) {
-	  sprintf(buf, "UT=%ld ", raw_time);
-	  strcat(datebuf, buf);
+  if (utime)
+  {
+    sprintf(buf, "UT=%ld ", raw_time);
+    strcat(datebuf, buf);
   }
 
-  if(gpsdev) {
+  if (gpsdev)
+  {
     sprintf(buf, "GWGPS_LAT=%-3.5f ", *gps_lat);
     strcat(datebuf, buf);
 
@@ -276,795 +285,896 @@ void print_report_header(char *gpsdev, char *datebuf)
     strcat(datebuf, buf);
   }
 
-  if(lat > GPS_MISS) {
+  if (lat > GPS_MISS)
+  {
     sprintf(buf, "GW_LAT=%-3.5f ", lat);
     strcat(datebuf, buf);
   }
 
-  if(lon > GPS_MISS) {
+  if (lon > GPS_MISS)
+  {
     sprintf(buf, "GW_LON=%-3.5f ", lon);
     strcat(datebuf, buf);
   }
 
-  if(domain) {
+  if (domain)
+  {
     sprintf(buf, "DOMAIN=%s ", domain);
     strcat(datebuf, buf);
   }
 }
 
-int do_report(const char *buf, const char *reportpath)
+int do_report(const char* buf, const char* reportpath)
 {
-	struct stat statb;
-	char *s = strdup(buf);
-	char *id = NULL;
-	char *val, *n;
-	char fn[512];
-	char tmpfn[512];
+  struct stat statb;
+  char* s = strdup(buf);
+  char* id = NULL;
+  char* val, *n;
+  char fn[512];
+  char tmpfn[512];
 
-	if(debug)
-	  printf("do_report \n");
+  if (debug)
+    printf("do_report \n");
 
-	while(*s) {
-		while(*s && *s == ' ') s++;
+  while (*s)
+  {
+    while (*s && *s == ' ')
+      s++;
 
-		n=s; while(*n && *n != ' ') n++;
-		if(*n) { *n = 0; n++; }
-		
-		val = strchr(s, '=');
-		if(val) {
-			*val++ = 0;
-			if(*s == '[') s++;
-			if(!*n) {
-				if(*val && val[strlen(val)-1] == '\n') val[strlen(val)-1] = 0;
-				if(*val && val[strlen(val)-1] == ']') val[strlen(val)-1] = 0;
-			}
-			/*
-			  We have 3 ID's for node. We select in order. 
-			  E64 -  EUI64 
-			  ID  -  DALLAS
-			  TXT -  Fri-text format
-			*/
+    n = s;
+    while (*n && *n != ' ')
+      n++;
+    if (*n)
+    {
+      *n = 0;
+      n++;
+    }
 
-			if(!id) {
-				if((strcmp(s, "TXT")==0) && *val) {
-					id = val;
-					snprintf(fn, sizeof(fn), "%s/%s", reportpath, id);
-					if(stat(fn, &statb)) {
-						mkdir(fn, 0755);
-					}
-				}
-			}
-			if(!id) {
-				if((strcmp(s, "E64")==0) && *val) {
-					id = val;
-					snprintf(fn, sizeof(fn), "%s/%s", reportpath, id);
-					if(stat(fn, &statb)) {
-						mkdir(fn, 0755);
-					}
-				}
-			}
-			if(!id) {
-				if((strcmp(s, "ID")==0) && *val) {
-					id = val;
-					snprintf(fn, sizeof(fn), "%s/%s", reportpath, id);
-					if(stat(fn, &statb)) {
-						mkdir(fn, 0755);
-					}
-				}
-			}
-			if(id && *val) {
-				int fd;
-				snprintf(fn, sizeof(fn), "%s/%s/%s", reportpath, id, s);
-				snprintf(tmpfn, sizeof(tmpfn), "%s/%s/%s.tmp", reportpath, id, s);
-				fd = open(tmpfn, O_WRONLY|O_TRUNC|O_CREAT, 0644);
-				if(fd >= 0) {
-					write(fd, val, strlen(val));
-					close(fd);
-					rename(tmpfn, fn);
-				}
-			}
-		}
-		s = n;
-	}
-	return 0;
+    val = strchr(s, '=');
+    if (val)
+    {
+      *val++ = 0;
+      if (*s == '[')
+        s++;
+      if (!*n)
+      {
+        if (*val && val[strlen(val) - 1] == '\n')
+          val[strlen(val) - 1] = 0;
+        if (*val && val[strlen(val) - 1] == ']')
+          val[strlen(val) - 1] = 0;
+      }
+      /*
+        We have 3 ID's for node. We select in order.
+        E64 -  EUI64
+        ID  -  DALLAS
+        TXT -  Fri-text format
+      */
+
+      if (!id)
+      {
+        if ((strcmp(s, "TXT") == 0) && *val)
+        {
+          id = val;
+          snprintf(fn, sizeof(fn), "%s/%s", reportpath, id);
+          if (stat(fn, &statb))
+          {
+            mkdir(fn, 0755);
+          }
+        }
+      }
+      if (!id)
+      {
+        if ((strcmp(s, "E64") == 0) && *val)
+        {
+          id = val;
+          snprintf(fn, sizeof(fn), "%s/%s", reportpath, id);
+          if (stat(fn, &statb))
+          {
+            mkdir(fn, 0755);
+          }
+        }
+      }
+      if (!id)
+      {
+        if ((strcmp(s, "ID") == 0) && *val)
+        {
+          id = val;
+          snprintf(fn, sizeof(fn), "%s/%s", reportpath, id);
+          if (stat(fn, &statb))
+          {
+            mkdir(fn, 0755);
+          }
+        }
+      }
+      if (id && *val)
+      {
+        int fd;
+        snprintf(fn, sizeof(fn), "%s/%s/%s", reportpath, id, s);
+        snprintf(tmpfn, sizeof(tmpfn), "%s/%s/%s.tmp", reportpath, id, s);
+        fd = open(tmpfn, O_WRONLY | O_TRUNC | O_CREAT, 0644);
+        if (fd >= 0)
+        {
+          write(fd, val, strlen(val));
+          close(fd);
+          rename(tmpfn, fn);
+        }
+      }
+    }
+    s = n;
+  }
+  return 0;
 }
 
 int set_term(int fd, int baud, struct termios tp)
 {
 
-	fcntl(fd, F_GETFL);
-	fcntl(fd, F_SETFL, O_RDWR);
+  fcntl(fd, F_GETFL);
+  fcntl(fd, F_SETFL, O_RDWR);
 
-/*
-SANE is a composite flag that sets the following parameters from termio(M):
+  /*
+  SANE is a composite flag that sets the following parameters from termio(M):
 
-CREAD BRKINT IGNPAR ICRNL IXON ISIG ICANON
-ECHO ECHOK OPOST ONLCR
+  CREAD BRKINT IGNPAR ICRNL IXON ISIG ICANON
+  ECHO ECHOK OPOST ONLCR
 
-SANE also clears the following modes:
+  SANE also clears the following modes:
 
-CLOCAL
-IGNBRK PARMRK INPCK INLCR IUCLC IXOFF
-XCASE ECHOE ECHONL NOFLSH
-OLCUC OCRNL ONOCR ONLRET OFILL OFDEL NLDLY CRDLY
-TABDLY BSDLY VTDLY FFDLY 
+  CLOCAL
+  IGNBRK PARMRK INPCK INLCR IUCLC IXOFF
+  XCASE ECHOE ECHONL NOFLSH
+  OLCUC OCRNL ONOCR ONLRET OFILL OFDEL NLDLY CRDLY
+  TABDLY BSDLY VTDLY FFDLY
 
-*/
-	/* 8 bits + baud rate + local control */
-	tp.c_cflag = baud | CS8 | CLOCAL | CREAD;
-	tp.c_oflag = 0; /* Raw Input */
-	tp.c_lflag = 0; /* No conoical */
-	tp.c_oflag &= ~(OLCUC|OCRNL|ONOCR|ONLRET|OFILL|OFDEL|NLDLY|CRDLY);
+  */
+  /* 8 bits + baud rate + local control */
+  tp.c_cflag = baud | CS8 | CLOCAL | CREAD;
+  tp.c_oflag = 0; /* Raw Input */
+  tp.c_lflag = 0; /* No conoical */
+  tp.c_oflag &= ~(OLCUC | OCRNL | ONOCR | ONLRET | OFILL | OFDEL | NLDLY | CRDLY);
 
+  /* ignore CR, ignore parity */
+  tp.c_iflag = ~(IGNBRK | PARMRK | INPCK | INLCR | IUCLC | IXOFF) | BRKINT | IGNPAR | ICRNL | IXON | ISIG | ICANON;
 
-	/* ignore CR, ignore parity */
-	tp.c_iflag = ~(IGNBRK|PARMRK|INPCK|INLCR|IUCLC|IXOFF) |
-	  BRKINT|IGNPAR|ICRNL|IXON|ISIG|ICANON;
+  tp.c_lflag &= ~(ECHO | ECHONL);
 
-	tp.c_lflag &= ~(ECHO  | ECHONL);
+  tcflush(fd, TCIFLUSH);
 
-	tcflush(fd, TCIFLUSH);
+  /* set output and input baud rates */
 
-	/* set output and input baud rates */
+  cfsetospeed(&tp, baud);
+  cfsetispeed(&tp, baud);
 
-	cfsetospeed(&tp, baud);
-	cfsetispeed(&tp, baud);
-
-	if (tcsetattr(fd, TCSANOW, &tp) < 0) {
-		perror("Couldn't set term attributes");
-		return(-1);
-	}
-	return 1;
+  if (tcsetattr(fd, TCSANOW, &tp) < 0)
+  {
+    perror("Couldn't set term attributes");
+    return (-1);
+  }
+  return 1;
 }
 
-int connect_remote(char *host, int port)
+int connect_remote(char* host, int port)
 {
-    struct sockaddr_in addr;
-    struct hostent *he;
-    int len, s, x, on = 1;
+  struct sockaddr_in addr;
+  struct hostent* he;
+  int len, s, x, on = 1;
 
-    he = gethostbyname(host);
-    if (!he)
-	return (-2);
+  he = gethostbyname(host);
+  if (!he)
+    return (-2);
 
-    len = sizeof(addr);
-    s = socket(AF_INET, SOCK_STREAM, 0);
-    if (s < 0)
-	return s;
-
-    setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &on, 4);
-
-    len = sizeof(addr);
-    memset(&addr, '\0', len);
-    addr.sin_family = AF_INET;
-    memcpy(&addr.sin_addr, he->h_addr, he->h_length);
-    addr.sin_port = htons(port);
-    x = connect(s, (struct sockaddr *) &addr, len);
-    if (x < 0) {
-	close(s);
-	return x;
-    }
-    //set_nonblock(s);
+  len = sizeof(addr);
+  s = socket(AF_INET, SOCK_STREAM, 0);
+  if (s < 0)
     return s;
+
+  setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &on, 4);
+
+  len = sizeof(addr);
+  memset(&addr, '\0', len);
+  addr.sin_family = AF_INET;
+  memcpy(&addr.sin_addr, he->h_addr, he->h_length);
+  addr.sin_port = htons(port);
+  x = connect(s, (struct sockaddr*)&addr, len);
+  if (x < 0)
+  {
+    close(s);
+    return x;
+  }
+  // set_nonblock(s);
+  return s;
 }
 
-int lissen(struct sockaddr_in addr, int port)
+int listensd(struct sockaddr_in addr, int port)
 {
-	int s = socket(AF_INET, SOCK_STREAM, 0);
-	int rc, on = 1;
+  int s = socket(AF_INET, SOCK_STREAM, 0);
+  int rc, on = 1;
 
-	if (s < 0)  { 
-		perror("socket() failed");
-		exit(-1);
-	}
+  if (s < 0)
+  {
+    perror("socket() failed");
+    exit(-1);
+  }
 
-	/* Allow socket descriptor to be reuseable */
-	rc = setsockopt(s, SOL_SOCKET,  SO_REUSEADDR,
-			(char *)&on, sizeof(on));
-	if (rc < 0)   {
-		perror("setsockopt() failed");
-		close(s);
-		exit(-1);
-	}
-	  
-	/* Set socket to be nonblocking. All of the sockets for    
-	   the incoming connections will also be nonblocking since  
-	   they will inherit that state from the listening socket.   */
-	  
-	rc = ioctl(s, FIONBIO, (char *)&on);
-	if (rc < 0)  {
-		perror("ioctl() failed");
-		close(s);
-		exit(-1);
-	}
-	  
-	memset(&addr, 0, sizeof(addr));
-	addr.sin_family      = AF_INET;
-	addr.sin_addr.s_addr = htonl(INADDR_ANY);
-	addr.sin_port        = htons(port);
-	  
-	rc = bind(s, (struct sockaddr *)&addr, sizeof(addr));
-	  
-	if (rc < 0)   {
-		perror("bind() failed");
-		close(s);
-		exit(-1);
-	}
+  /* Allow socket descriptor to be reuseable */
+  rc = setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char*)&on, sizeof(on));
+  if (rc < 0)
+  {
+    perror("setsockopt() failed");
+    close(s);
+    exit(-1);
+  }
 
-	/* Set the listen back log  */
+  /* Set socket to be nonblocking. All of the sockets for
+     the incoming connections will also be nonblocking since
+     they will inherit that state from the listening socket.   */
 
-	rc = listen(s, 32);
-	  
-	if (rc < 0)   {
-		perror("listen() failed");
-		close(s);
-		exit(-1);
-	}
-	return s;
+  rc = ioctl(s, FIONBIO, (char*)&on);
+  if (rc < 0)
+  {
+    perror("ioctl() failed");
+    close(s);
+    exit(-1);
+  }
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(port);
+
+  rc = bind(s, (struct sockaddr*)&addr, sizeof(addr));
+
+  if (rc < 0)
+  {
+    perror("bind() failed");
+    close(s);
+    exit(-1);
+  }
+
+  /* Set the listen back log  */
+
+  rc = listen(s, 32);
+
+  if (rc < 0)
+  {
+    perror("listen() failed");
+    close(s);
+    exit(-1);
+  }
+  return s;
 }
 
-int main(int ac, char *av[]) 
+int main(int ac, char* av[])
 {
   struct termios tp, tp_usb_old, tp_gps_old;
-	int usb_fd;
-	int file_fd;
-	int gps_fd;
-	int send_host_sd = -1;
-	int receive = 0;
-	int receive_time_local = 0;
-	char io[BUFSIZE];
-	char buf[BUFSIZE];
-	char *filename = NULL;
-	char *gpsdev = NULL;
-	char *reportpath = NULL;
-	unsigned short filedev = 0;
-	int res;
-	int i, len;
-	char *serialdev = NULL;
-	int    rc;
-	int    listen_sd = -1, new_sd = -1;
-	int    compress_array = FALSE;
-	int    close_conn;
-	char   buffer[BUFSIZE];
-	char   *send_host = NULL;
-	struct sockaddr_in   addr;
-	int    timeout;
-	struct pollfd fds[200];
-	int    nfds = 2, current_size = 0, j;
-	int    send_2_listners;
-	unsigned short port = SERVER_PORT;
-	int send_port = SEND_PORT;
-	unsigned short report = 0;
-	struct sockaddr saddr;
-	socklen_t saddr_len = sizeof(saddr);
+  int usb_fd;
+  int file_fd;
+  int gps_fd;
+  int send_host_sd = -1;
+  int receive = 0;
+  int receive_time_local = 0;
+  char io[BUFSIZE];
+  char buf[BUFSIZE];
+  char* filename = NULL;
+  char* gpsdev = NULL;
+  char* reportpath = NULL;
+  unsigned short filedev = 0;
+  int res;
+  int i, len;
+  char* serialdev = NULL;
+  int rc;
+  int listen_sd = -1, new_sd = -1;
+  int compress_array = FALSE;
+  int close_conn;
+  char buffer[BUFSIZE];
+  char* send_host = NULL;
+  struct sockaddr_in addr;
+  int timeout;
+  struct pollfd fds[200];
+  int nfds = 2, current_size = 0, j;
+  int send_2_listners;
+  unsigned short port = SERVER_PORT;
+  int send_port = SEND_PORT;
+  unsigned short report = 0;
+  struct sockaddr saddr;
+  socklen_t saddr_len = sizeof(saddr);
 
-	baud = B38400;
-	background = 1;
-	date = 1;
-	utime = 1;
-	utc = 0;
-	filename = LOGFILE;
+  baud = B38400;
+  background = 1;
+  date = 1;
+  utime = 1;
+  utc = 0;
+  filename = LOGFILE;
 
-	if(ac == 1) 
-	  usage();
+  if (ac == 1)
+    usage();
 
-	for(i = 1; (i < ac) && (av[i][0] == '-'); i++)  {
-	    if (strcmp(av[i], "-300") == 0) 
-	      baud = B300;
+  for (i = 1; (i < ac) && (av[i][0] == '-'); i++)
+  {
+    if (strcmp(av[i], "-300") == 0)
+      baud = B300;
 
-	    else if (strcmp(av[i], "-600") == 0) 
-	      baud = B600;
+    else if (strcmp(av[i], "-600") == 0)
+      baud = B600;
 
-	    else if (strcmp(av[i], "-1200") == 0) 
-	      baud = B1200;
+    else if (strcmp(av[i], "-1200") == 0)
+      baud = B1200;
 
-	    else if (strcmp(av[i], "-2400") == 0) 
-	      baud = B2400;
+    else if (strcmp(av[i], "-2400") == 0)
+      baud = B2400;
 
-	    else if (strcmp(av[i], "-4800") == 0) 
-	      baud = B4800;
+    else if (strcmp(av[i], "-4800") == 0)
+      baud = B4800;
 
-	    else if (strcmp(av[i], "-9600") == 0)
-	      baud = B9600;
+    else if (strcmp(av[i], "-9600") == 0)
+      baud = B9600;
 
-	    else if (strcmp(av[i], "-19200") == 0)
-	      baud = B19200;
+    else if (strcmp(av[i], "-19200") == 0)
+      baud = B19200;
 
-	    else if (strcmp(av[i], "-38400") == 0)
-	      baud = B38400;
+    else if (strcmp(av[i], "-38400") == 0)
+      baud = B38400;
 
-	    else if (strcmp(av[i], "-utime") == 0) 
-	      utime = 1;
+    else if (strcmp(av[i], "-utime") == 0)
+      utime = 1;
 
-	    else if (strcmp(av[i], "-utc") == 0) 
-	      utc = 1;
+    else if (strcmp(av[i], "-utc") == 0)
+      utc = 1;
 
-	    else if (strcmp(av[i], "-b") == 0) 
-	      background = 1;
+    else if (strcmp(av[i], "-b") == 0)
+      background = 1;
 
-	    else if (strncmp(av[i], "-f", 2) == 0) 
-	      filename = av[++i];
+    else if (strncmp(av[i], "-f", 2) == 0)
+      filename = av[++i];
 
-	    else if (strncmp(av[i], "-g", 2) == 0) 
-	      gpsdev = av[++i];
+    else if (strncmp(av[i], "-g", 2) == 0)
+      gpsdev = av[++i];
 
-	    else if (strncmp(av[i], "-R", 2) == 0) {
-	      reportpath = av[++i];
-	      if(!*reportpath) reportpath = "/var/lib/sensd";
-	    }
+    else if (strncmp(av[i], "-R", 2) == 0)
+    {
+      reportpath = av[++i];
+      if (!*reportpath)
+        reportpath = "/var/lib/sensd";
+    }
 
-	    else if (strncmp(av[i], "-debug", 6) == 0) {
-	      debug = 1;
-	    }
+    else if (strncmp(av[i], "-debug", 6) == 0)
+    {
+      debug = 1;
+    }
 
-	    else if (strncmp(av[i], "-domain", 7) == 0) {
-	      domain = av[++i];
-	    }
-	    
-	    else if (strncmp(av[i], "-send_port", 9) == 0) {
-	      send_port = atoi(av[++i]);
-	    }
+    else if (strncmp(av[i], "-domain", 7) == 0)
+    {
+      domain = av[++i];
+    }
 
-	    else if (strcmp(av[i], "-send") == 0) {
-	      send_host = av[++i];
-	    }
+    else if (strncmp(av[i], "-send_port", 9) == 0)
+    {
+      send_port = atoi(av[++i]);
+    }
 
-	    else if (strncmp(av[i], "-p", 2) == 0) {
-	      port = atoi(av[++i]);
-	    }
+    else if (strcmp(av[i], "-send") == 0)
+    {
+      send_host = av[++i];
+    }
 
-	    else if (strncmp(av[i], "-D", 2) == 0) {
-	      serialdev = av[++i];
-	    }
+    else if (strncmp(av[i], "-p", 2) == 0)
+    {
+      port = atoi(av[++i]);
+    }
 
-	    else if (strncmp(av[i], "-receive_time_local", 10) == 0) 
-	      receive_time_local = 1;
+    else if (strncmp(av[i], "-D", 2) == 0)
+    {
+      serialdev = av[++i];
+    }
 
-	    else if (strncmp(av[i], "-receive", 4) == 0) 
-	      receive = 1;
+    else if (strncmp(av[i], "-receive_time_local", 10) == 0)
+      receive_time_local = 1;
 
-	    else if (strcmp(av[i], "-report") == 0) 
-	      report = 1;
+    else if (strncmp(av[i], "-receive", 4) == 0)
+      receive = 1;
 
-	    else if (strcmp(av[i], "-infile") == 0) 
-	      filedev = 1;
+    else if (strcmp(av[i], "-report") == 0)
+      report = 1;
 
-	    else if (strncmp(av[i], "-LON", 4) == 0)
-	      lon = strtod(av[++i], NULL);
+    else if (strcmp(av[i], "-infile") == 0)
+      filedev = 1;
 
-	    else if (strncmp(av[i], "-LAT", 4) == 0) 
-	      lat = strtod(av[++i], NULL);
+    else if (strncmp(av[i], "-LON", 4) == 0)
+      lon = strtod(av[++i], NULL);
 
-	    else
-	      usage();
+    else if (strncmp(av[i], "-LAT", 4) == 0)
+      lat = strtod(av[++i], NULL);
 
-	  }
+    else
+      usage();
+  }
 
-	if(debug) {
-	  printf("send_port=%d\n", send_port);
-	  printf("send_host=%s\n", send_host);
-	  printf("domain=%s\n", domain);
-	  printf("receive=%d\n", receive);
-	  printf("receive_time_local=%d\n", receive_time_local);
-	  printf("reportpath=%s\n", reportpath);
-	}
+  if (debug)
+  {
+    printf("send_port=%d\n", send_port);
+    printf("send_host=%s\n", send_host);
+    printf("domain=%s\n", domain);
+    printf("receive=%d\n", receive);
+    printf("receive_time_local=%d\n", receive_time_local);
+    printf("reportpath=%s\n", reportpath);
+  }
 
-	if(reportpath) {
-		struct stat statb;
-		if(stat(reportpath, &statb)) {
-			fprintf(stderr, "Failed to open '%s'\n", reportpath);
-			exit(2);
-		}
-	}
+  if (reportpath)
+  {
+    struct stat statb;
+    if (stat(reportpath, &statb))
+    {
+      fprintf(stderr, "Failed to open '%s'\n", reportpath);
+      exit(2);
+    }
+  }
 
-	if(filename) {
-		file_fd = open(filename, O_CREAT|O_RDWR|O_APPEND, 0644);
-		if(file_fd < 0) {
-			fprintf(stderr, "Failed to open '%s'\n", filename);
-			exit(2);
-		}
-	}
+  if (filename)
+  {
+    file_fd = open(filename, O_CREAT | O_RDWR | O_APPEND, 0644);
+    if (file_fd < 0)
+    {
+      fprintf(stderr, "Failed to open '%s'\n", filename);
+      exit(2);
+    }
+  }
 
-	if(gpsdev) {
-	  gps_fd = open(devtag_get(gpsdev), O_RDWR | O_NOCTTY | O_NONBLOCK);
-	  if(gps_fd < 0) {
-	    fprintf(stderr, "Failed to open '%s'\n", gpsdev);
-	    exit(2);
-	  }
-	  
-	  if (tcgetattr(gps_fd, &tp) < 0) {
-		perror("Couldn't get term attributes");
-		exit(-1);
-	  }
-	  tp_gps_old = tp;
+  if (gpsdev)
+  {
+    gps_fd = open(devtag_get(gpsdev), O_RDWR | O_NOCTTY | O_NONBLOCK);
+    if (gps_fd < 0)
+    {
+      fprintf(stderr, "Failed to open '%s'\n", gpsdev);
+      exit(2);
+    }
 
-	  if( set_term(gps_fd, B4800, tp) != 1)
-	    exit(-1);
-	}
-	  
-	if(serialdev) {
-	  strncpy(dial_tty, devtag_get(serialdev), sizeof(dial_tty));
-	  while (! get_lock()) {
-	    if(--retry == 0)
-	      exit(-1);
-	    sleep(1);
-	  }
+    if (tcgetattr(gps_fd, &tp) < 0)
+    {
+      perror("Couldn't get term attributes");
+      exit(-1);
+    }
+    tp_gps_old = tp;
 
-	  if ((usb_fd = open(devtag_get(serialdev), O_RDWR | O_NOCTTY | O_NONBLOCK)) < 0) {
-	    perror("bad terminal device, try another");
-	    exit(-1);
-	  }
-	  
-	  if (tcgetattr(usb_fd, &tp) < 0) {
-	    perror("Couldn't get term attributes");
-	    exit(-1);
-	  }
-	  tp_usb_old = tp;
-	  
-	  if( set_term(usb_fd, baud, tp) != 1)
-	    exit(-1);
-	}
+    if (set_term(gps_fd, B4800, tp) != 1)
+      exit(-1);
+  }
 
-	if(filedev) {
-		usb_fd = open(av[i],O_RDONLY);
-		if(usb_fd < 0) {
-			fprintf(stderr, "Failed to open filedev '%s'\n", filename);
-			exit(2);
-		}
-	} 
+  if (serialdev)
+  {
+    strncpy(dial_tty, devtag_get(serialdev), sizeof(dial_tty));
+    while (!get_lock())
+    {
+      if (--retry == 0)
+        exit(-1);
+      sleep(1);
+    }
 
-	if(gpsdev) {
-	  gps_lat = mmap(NULL, sizeof(gps_lat), PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0);
-	  if( gps_lat == (void *) -1) {
-	    perror("mmap");
-	    exit(-1);
-	  }
-	  gps_lon = mmap(NULL, sizeof(gps_lon), PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0);
-	  if( gps_lon == (void *) -1) {
-	    perror("mmap");
-	    exit(-1);
-	  }
-	}
+    if ((usb_fd = open(devtag_get(serialdev), O_RDWR | O_NOCTTY | O_NONBLOCK)) < 0)
+    {
+      perror("bad terminal device, try another");
+      exit(-1);
+    }
 
+    if (tcgetattr(usb_fd, &tp) < 0)
+    {
+      perror("Couldn't get term attributes");
+      exit(-1);
+    }
+    tp_usb_old = tp;
 
-	/* Term ok deal w. text to send */
-	
-	if(background) {
-	  int i;
-	  if(getppid() == 1) 
-	    return 0; /* Already a daemon */
+    if (set_term(usb_fd, baud, tp) != 1)
+      exit(-1);
+  }
 
-	  i = fork();
+  if (filedev)
+  {
+    usb_fd = open(av[i], O_RDONLY);
+    if (usb_fd < 0)
+    {
+      fprintf(stderr, "Failed to open filedev '%s'\n", filename);
+      exit(2);
+    }
+  }
 
-	  if (i < 0) 
-	    exit(1); /* error */
+  if (gpsdev)
+  {
+    gps_lat = mmap(NULL, sizeof(gps_lat), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (gps_lat == (void*)-1)
+    {
+      perror("mmap");
+      exit(-1);
+    }
+    gps_lon = mmap(NULL, sizeof(gps_lon), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (gps_lon == (void*)-1)
+    {
+      perror("mmap");
+      exit(-1);
+    }
+  }
 
-	  if (i > 0) 
-	    _exit(0); /* parent exits */
+  /* Term ok deal w. text to send */
 
-	  /* gps child */
+  if (background)
+  {
+    int i;
+    if (getppid() == 1)
+      return 0; /* Already a daemon */
 
-	  if( gpsdev && fork() == 0)  {
-	    int j;
-	    setsid(); /* obtain a new process group */
-	    for (j = getdtablesize(); j >= 0; --j) {
-	      if(j == gps_fd) continue;
-	    }
-	    j = open("/dev/null",O_RDWR); dup(i); dup(i); /* handle standard I/O */
-	    umask(027); /* set newly created file permissions */
-	    chdir("/"); /* change running directory */
+    i = fork();
 
-	    while(1) {
-	      j = gps_read(gps_fd, gps_lon, gps_lat);
-	      if(j == -1) {
-		*gps_lon = *gps_lat = GPS_MISS;
-	      }
-	      sleep(5);
-	    }
-	  }
+    if (i < 0)
+      exit(1); /* error */
 
-	  /* poll child */
-	  
-	  setsid(); /* obtain a new process group */
-	  for (i = getdtablesize(); i >= 0; --i) {
-		  if(i == gps_fd) continue;
-		  if(i == usb_fd) continue;
-		  if(i == file_fd) continue;
-		  if(debug && i == 1) continue;
-	    close(i); /* close all descriptors */
-	  }
+    if (i > 0)
+      _exit(0); /* parent exits */
 
-	  i = open("/dev/null",O_RDWR); dup(i); dup(i); /* handle standard I/O */
-	  umask(027); /* set newly created file permissions */
-	  chdir("/"); /* change running directory */
+    /* gps child */
+
+    if (gpsdev && fork() == 0)
+    {
+      int j;
+      setsid(); /* obtain a new process group */
+      for (j = getdtablesize(); j >= 0; --j)
+      {
+        if (j == gps_fd)
+          continue;
+      }
+      j = open("/dev/null", O_RDWR);
+      dup(i);
+      dup(i);     /* handle standard I/O */
+      umask(027); /* set newly created file permissions */
+      chdir("/"); /* change running directory */
+
+      while (1)
+      {
+        j = gps_read(gps_fd, gps_lon, gps_lat);
+        if (j == -1)
+        {
+          *gps_lon = *gps_lat = GPS_MISS;
+        }
+        sleep(5);
+      }
+    }
+
+    /* poll child */
+
+    setsid(); /* obtain a new process group */
+    for (i = getdtablesize(); i >= 0; --i)
+    {
+      if (i == gps_fd)
+        continue;
+      if (i == usb_fd)
+        continue;
+      if (i == file_fd)
+        continue;
+      if (debug && i == 1)
+        continue;
+      close(i); /* close all descriptors */
+    }
+
+    i = open("/dev/null", O_RDWR);
+    dup(i);
+    dup(i);     /* handle standard I/O */
+    umask(027); /* set newly created file permissions */
+    chdir("/"); /* change running directory */
 #if 0
-	  lfp = open(LOCK_FILE,O_RDWR|O_CREAT,0640);
-	  if (lfp < 0) exit(1); /* can not open */
+    lfp = open(LOCK_FILE,O_RDWR|O_CREAT,0640);
+    if (lfp < 0) exit(1); /* can not open */
 
-	  if (lockf(lfp, F_TLOCK,0) <0 ) 
-	    exit(0); /* can not lock */
-	  /* first instance continues */
-	  sprintf(str,"%d\n",getpid());
-	  write(lfp,str,strlen(str)); /* record pid to lockfile */
-	  signal(SIGCHLD,SIG_IGN); /* ignore child */
-	  signal(SIGTSTP,SIG_IGN); /* ignore tty signals */
-	  signal(SIGTTOU,SIG_IGN);
-	  signal(SIGTTIN,SIG_IGN);
-	  signal(SIGHUP,signal_handler); /* catch hangup signal */
-	  signal(SIGTERM,signal_handler); /* catch kill signal */
+    if (lockf(lfp, F_TLOCK,0) <0 )
+      exit(0); /* can not lock */
+    /* first instance continues */
+    sprintf(str,"%d\n",getpid());
+    write(lfp,str,strlen(str)); /* record pid to lockfile */
+    signal(SIGCHLD,SIG_IGN); /* ignore child */
+    signal(SIGTSTP,SIG_IGN); /* ignore tty signals */
+    signal(SIGTTOU,SIG_IGN);
+    signal(SIGTTIN,SIG_IGN);
+    signal(SIGHUP,signal_handler); /* catch hangup signal */
+    signal(SIGTERM,signal_handler); /* catch kill signal */
 #endif
-	}
+  }
 
-	if(reportpath) umask(0);
-	
+  if (reportpath)
+    umask(0);
 
-	listen_sd = lissen(addr, port);
+  listen_sd = listensd(addr, port);
 
-	memset(fds, 0 , sizeof(fds));
+  memset(fds, 0, sizeof(fds));
 
-	/* Add initial listening sockets  */
+  /* Add initial listening sockets  */
 
-	nfds = 0;
-	fds[nfds].fd = listen_sd;
-	fds[nfds].events = POLLIN;
-	nfds++;
+  nfds = 0;
+  fds[nfds].fd = listen_sd;
+  fds[nfds].events = POLLIN;
+  nfds++;
 
-	if(serialdev) {
-	  fds[nfds].fd = usb_fd;
-	  fds[nfds].events = POLLIN;
-	  nfds++;
-	}
+  if (serialdev)
+  {
+    fds[nfds].fd = usb_fd;
+    fds[nfds].events = POLLIN;
+    nfds++;
+  }
 
-	j = 0;
+  j = 0;
 
-	while (1)  {
-	  int i, ii;
-	  static int proxy_start = 0;
-	  char outbuf[BUFSIZ];
+  while (1)
+  {
+    int i, ii;
+    static int proxy_start = 0;
+    char outbuf[BUFSIZ];
 
-	  if (proxy_start++ == 0)
-	    timeout = (10);
-	  else 
-	    timeout = 2000;
+    if (proxy_start++ == 0)
+      timeout = (10);
+    else
+      timeout = 2000;
 
-	  rc = poll(fds, nfds, timeout);
-	    send_2_listners = 0;
-	    
-	    if (rc < 0)  {
-	      //perror("  poll() failed");
-	      break;
-	    }
-	    
-	    if (rc == 0)  {
-	      /* TIMEOUT: Try (re)-connect to proxy */
-	      if(send_host && (send_host_sd == -1)) {
+    rc = poll(fds, nfds, timeout);
+    send_2_listners = 0;
 
-		if(debug)
-		  printf("Trying %s on port %d. Connect ", send_host, send_port);
+    if (rc < 0)
+    {
+      // perror("  poll() failed");
+      break;
+    }
 
-		send_host_sd = connect_remote(send_host, send_port);
-		if (send_host_sd >= 0) {
-		  fds[nfds].fd = send_host_sd;
-		  fds[nfds].events = POLLIN;
-		  nfds++;
-		  if(debug)
-		    printf("succeded\n");
-		}
-		else {
-		  send_host_sd = -1;
-		  if(debug)
-		    perror("connect");
-		}
-	      }
-	      continue;
-	    }
+    if (rc == 0)
+    {
+      /* TIMEOUT: Try (re)-connect to proxy */
+      if (send_host && (send_host_sd == -1))
+      {
 
-	    current_size = nfds;
-	    for (i = 0; i < current_size; i++)   {
-	      
-	      if(fds[i].revents == 0)
-		continue;
-	      
-	      send_2_listners = 0;
+        if (debug)
+          printf("Trying %s on port %d. Connect ", send_host, send_port);
 
-	      /* Buffers used
-		 io      : USB read buffer
-		 outbuf  : whar's written to sensors.dat and port listers
-		 buf temp: split USB read code
-		 buffer  : read buffer from port listerners
-	      */
+        send_host_sd = connect_remote(send_host, send_port);
+        if (send_host_sd >= 0)
+        {
+          fds[nfds].fd = send_host_sd;
+          fds[nfds].events = POLLIN;
+          nfds++;
+          if (debug)
+            printf("succeded\n");
+        }
+        else
+        {
+          send_host_sd = -1;
+          if (debug)
+            perror("connect");
+        }
+      }
+      continue;
+    }
 
-	      if (fds[i].fd == usb_fd && fds[i].revents & POLLIN)   {
-		memset(io,0,BUFSIZE);
-		res = read(usb_fd, io, BUFSIZE);
-		if(res > BUFSIZE){
-		}
-		else
-		  strcat(buf, "ERR read\n");
-	        if(filedev){
-		  /* We have input in one line */
-		    if(io[0] == '&' && io[1] == ':' && (date || utime))
-		      print_report_header(gpsdev, outbuf);
-		    strcat(outbuf, io);
-		    write(file_fd, outbuf, strlen(outbuf));
-		    if(reportpath) 
-		      do_report(buf, reportpath);
+    current_size = nfds;
+    for (i = 0; i < current_size; i++)
+    {
 
-		    if(report)
-		      send_2_listners = 1;
+      if (fds[i].revents == 0)
+        continue;
 
-		}else{
+      send_2_listners = 0;
 
-		  for(ii=0; ii < res; ii++, j++)  {
-		    if(io[ii] == END_OF_FILE) {
-		      outbuf[0] = 0;
-		      if(buf[0] == '&' && buf[1] == ':' && (date || utime))
-		        print_report_header(gpsdev, outbuf);
-		      else{ 
-		        strcat(outbuf, "ERR missing signature");
-		      }
-		      buf[j] = 0;
-		      strcat(outbuf, buf);
-		      write(file_fd, outbuf, strlen(outbuf));
-		      if(reportpath) 
-		        do_report(buf, reportpath);
+      /* Buffers used
+         io      : USB read buffer
+         outbuf  : whar's written to sensors.dat and port listers
+         buf temp: split USB read code
+         buffer  : read buffer from port listerners
+      */
 
-		      if(report)
-		        send_2_listners = 1;
+      if (fds[i].fd == usb_fd && fds[i].revents & POLLIN)
+      {
+        memset(io, 0, BUFSIZE);
+        res = read(usb_fd, io, BUFSIZE);
+        if (res > BUFSIZE)
+        {
+        }
+        else
+          strcat(buf, "ERR read\n");
+        if (filedev)
+        {
+          /* We have input in one line */
+          if (io[0] == '&' && io[1] == ':' && (date || utime))
+            print_report_header(gpsdev, outbuf);
+          strcat(outbuf, io);
+          write(file_fd, outbuf, strlen(outbuf));
+          if (reportpath)
+            do_report(buf, reportpath);
 
-		      j = -1;
-		  
-		    }
-		    else  {
-		      buf[j] = io[ii];
-		    }
-		  }
-		}
-		fds[i].revents &= ~POLLIN;
-	      }
+          if (report)
+            send_2_listners = 1;
+        }
+        else
+        {
 
-	      if (fds[i].fd == listen_sd && fds[i].revents & POLLIN)   {
+          for (ii = 0; ii < res; ii++, j++)
+          {
+            if (io[ii] == END_OF_FILE)
+            {
+              outbuf[0] = 0;
+              if (buf[0] == '&' && buf[1] == ':' && (date || utime))
+                print_report_header(gpsdev, outbuf);
+              else
+              {
+                strcat(outbuf, "ERR missing signature");
+              }
+              buf[j] = 0;
+              strcat(outbuf, buf);
+              write(file_fd, outbuf, strlen(outbuf));
+              if (reportpath)
+                do_report(buf, reportpath);
 
-		new_sd = accept(listen_sd, NULL, NULL);
-		if (new_sd != -1)  {
-		  if(debug)
-		    printf("  New incoming listner connection - %d\n", new_sd);
-		  fds[nfds].fd = new_sd;
-		  fds[nfds].events = POLLIN;
-		  nfds++;
-		}
-		fds[i].revents &= ~POLLIN;
-	      }
+              if (report)
+                send_2_listners = 1;
 
-	      if (fds[i].revents & POLLIN)  {
-		close_conn = FALSE;
+              j = -1;
+            }
+            else
+            {
+              buf[j] = io[ii];
+            }
+          }
+        }
+        fds[i].revents &= ~POLLIN;
+      }
 
-		rc = recv(fds[i].fd, buffer, sizeof(buffer), 0);
-		if (rc < 0)  {
-		  if (errno != EWOULDBLOCK)  {
-		    close_conn = TRUE;
-		  }
-		  break;
-		}
-		  
-		if (rc == 0) 
-		  close_conn = TRUE;
+      if (fds[i].fd == listen_sd && fds[i].revents & POLLIN)
+      {
 
-		if(rc > 0 && receive) {
-		  len = rc;
-		  buffer[len-1] = ' ';
-		  memset(&saddr, 0, sizeof(saddr));
-		  memset(&outbuf, 0, sizeof(outbuf));
-		  saddr_len = sizeof(saddr);
+        new_sd = accept(listen_sd, NULL, NULL);
+        if (new_sd != -1)
+        {
+          if (debug)
+            printf("  New incoming listner connection - %d\n", new_sd);
+          fds[nfds].fd = new_sd;
+          fds[nfds].events = POLLIN;
+          nfds++;
+        }
+        fds[i].revents &= ~POLLIN;
+      }
 
-		  getpeername(fds[i].fd, (struct sockaddr *)&saddr, &saddr_len);
+      if (fds[i].revents & POLLIN)
+      {
+        close_conn = FALSE;
 
-		  {
-		    struct sockaddr_in *v4 =  (struct sockaddr_in *) &saddr;
-		    sprintf(outbuf, "%s SRC=%s\n", buffer, inet_ntoa(v4->sin_addr));
-		    memset(&buffer, 0, sizeof(buffer));
+        rc = recv(fds[i].fd, buffer, sizeof(buffer), 0);
+        if (rc < 0)
+        {
+          if (errno != EWOULDBLOCK)
+          {
+            close_conn = TRUE;
+          }
+          break;
+        }
 
-		    /* override incoming time*/
-		    if(receive_time_local)
-		      print_report_time(&outbuf[0]);
+        if (rc == 0)
+          close_conn = TRUE;
 
-		  }
-		  send_2_listners = 1;
+        if (rc > 0 && receive)
+        {
+          len = rc;
+          buffer[len - 1] = ' ';
+          memset(&saddr, 0, sizeof(saddr));
+          memset(&outbuf, 0, sizeof(outbuf));
+          saddr_len = sizeof(saddr);
+
+          getpeername(fds[i].fd, (struct sockaddr*)&saddr, &saddr_len);
+
+          {
+            struct sockaddr_in* v4 = (struct sockaddr_in*)&saddr;
+            sprintf(outbuf, "%s SRC=%s\n", buffer, inet_ntoa(v4->sin_addr));
+            memset(&buffer, 0, sizeof(buffer));
+
+            /* override incoming time*/
+            if (receive_time_local)
+              print_report_time(&outbuf[0]);
+          }
+          send_2_listners = 1;
 #if 0
-		  if(cmd) 
-		    rc = write(usb_fd, &buffer, len);
-		  else 
-		    rc = send(fds[i].fd, buffer, len, 0);
+          if(cmd)
+            rc = write(usb_fd, &buffer, len);
+          else
+            rc = send(fds[i].fd, buffer, len, 0);
 #endif
-		}
+        }
 
-		if (rc < 0)  
-		  close_conn = TRUE;
-		
-		if (close_conn)  {
-		  close(fds[i].fd);
+        if (rc < 0)
+          close_conn = TRUE;
 
-		  if(fds[i].fd == send_host_sd) {
-		   send_host_sd = -1;
+        if (close_conn)
+        {
+          close(fds[i].fd);
 
-		   if(debug)
-		     printf("Closed connection to %s on port %d \n", send_host, send_port);
-		  }
-		  fds[i].fd = -1;
-		  compress_array = TRUE;
-		}
-	      }  /* End of existing connection */
-	      fds[i].revents = 0;
-	    } /* Loop pollable descriptors */
+          if (fds[i].fd == send_host_sd)
+          {
+            send_host_sd = -1;
 
-	    /* Squeeze the array and decrement the number of file 
-	       descriptors. We do not need to move back the events 
-	       and  revents fields because the events will always
-	       be POLLIN in this case, and revents is output.  */
-	    
+            if (debug)
+              printf("Closed connection to %s on port %d \n", send_host, send_port);
+          }
+          fds[i].fd = -1;
+          compress_array = TRUE;
+        }
+      } /* End of existing connection */
+      fds[i].revents = 0;
+    } /* Loop pollable descriptors */
 
-	    if (compress_array)  {
-	      compress_array = FALSE;
-	      for (i = 0; i < nfds; i++)  {
-		if (fds[i].fd == -1)  {
-		  for(j = i; j < nfds; j++)  {
-		    fds[j].fd = fds[j+1].fd;
-		  }
-		  nfds--;
-		}
-	      }
-	    }
+    /* Squeeze the array and decrement the number of file
+       descriptors. We do not need to move back the events
+       and  revents fields because the events will always
+       be POLLIN in this case, and revents is output.  */
 
-	    if(send_2_listners) {
-	      current_size = nfds;
-	      for (i = 0; i < current_size; i++)   {
+    if (compress_array)
+    {
+      compress_array = FALSE;
+      for (i = 0; i < nfds; i++)
+      {
+        if (fds[i].fd == -1)
+        {
+          for (j = i; j < nfds; j++)
+          {
+            fds[j].fd = fds[j + 1].fd;
+          }
+          nfds--;
+        }
+      }
+    }
 
+    if (send_2_listners)
+    {
+      current_size = nfds;
+      for (i = 0; i < current_size; i++)
+      {
 
-		if (fds[i].fd == usb_fd)
-		  continue;
-		
-		if (fds[i].fd == listen_sd)
-		  continue;
+        if (fds[i].fd == usb_fd)
+          continue;
 
-		len = strlen(outbuf);
-		rc = send(fds[i].fd, outbuf, len, 0);
-		
-		if (rc < 0)  {
-		  close_conn = TRUE;
-		  break;
-		}
-	      }
-	    }
-	}
+        if (fds[i].fd == listen_sd)
+          continue;
 
-	if(gpsdev) {
-	  munmap(gps_lon, sizeof(gps_lon));
-	  munmap(gps_lat, sizeof(gps_lat));
-	}
-	if(!filedev){
-		if (tcsetattr(usb_fd, TCSANOW, &tp_usb_old) < 0) {
-		  perror("Couldn't restore term attributes");
-		  exit(-1);
-		}
-	}
+        len = strlen(outbuf);
+        rc = send(fds[i].fd, outbuf, len, 0);
 
-	if(gpsdev) {
-	  if (tcsetattr(gps_fd, TCSANOW, &tp_gps_old) < 0) {
-	    perror("Couldn't restore term attributes");
-	    exit(-1);
-	  }
-	}
+        if (rc < 0)
+        {
+          close_conn = TRUE;
+          break;
+        }
+      }
+    }
+  }
 
-	if(serialdev)
-	  lockfile_remove();
-	exit(0);
+  if (gpsdev)
+  {
+    munmap(gps_lon, sizeof(gps_lon));
+    munmap(gps_lat, sizeof(gps_lat));
+  }
+  if (!filedev)
+  {
+    if (tcsetattr(usb_fd, TCSANOW, &tp_usb_old) < 0)
+    {
+      perror("Couldn't restore term attributes");
+      exit(-1);
+    }
+  }
+
+  if (gpsdev)
+  {
+    if (tcsetattr(gps_fd, TCSANOW, &tp_gps_old) < 0)
+    {
+      perror("Couldn't restore term attributes");
+      exit(-1);
+    }
+  }
+
+  if (serialdev)
+    lockfile_remove();
+  exit(0);
 }
 
+#define BUFLEN 124
+#define KNOT_TO_KMPH 1.852
 
-#define BUFLEN  124
-#define KNOT_TO_KMPH 1.852 
-
-int gps_read(int fd, float *lon, float *lat)
+int gps_read(int fd, float* lon, float* lat)
 {
 
   int bp;
@@ -1072,62 +1182,66 @@ int gps_read(int fd, float *lon, float *lat)
 
   float course, speed;
   char foo[6], buf[BUFLEN], valid, ns, ew;
-  int try, res, maxtry = 10;
+  int try
+    , res, maxtry = 10;
   unsigned int year, mon, day, hour, min, sec;
   int done = 0;
 
-  for(try = 0; !done && try < maxtry; try++) {
+  for (try = 0; !done && try < maxtry; try ++)
+        {
 
-    bp = 0;
+          bp = 0;
 
-    while(bp < BUFLEN) {
-      int n, ok;
-      char b;
-      struct pollfd pfd;
-      
-      pfd.fd = fd;
-      pfd.events = POLLIN;
-      ok = poll( &pfd, 1, -1 );
-      
-    if ( ok < 0 ) 
-	continue;
-      
-      n = read(fd, &b, 1);
-      
-      if( n < 0)
-	continue;
-     
-      buf[bp++] = b;
-      if(b == '\n') 
-	break;
-    }
+          while (bp < BUFLEN)
+          {
+            int n, ok;
+            char b;
+            struct pollfd pfd;
 
-    if(strncmp("$GPRMC", buf, 6) == 0 ) {
-      
-      if(debug)
-	printf("%s", buf);
-      
-      res = sscanf(buf, 
-		   "$GPRMC,%2d%2d%2d.%3c,%1c,%f,%1c,%f,%1c,%f,%f,%2d%2d%2d",
-		   &hour, &min, &sec, foo, &valid, lat, &ns, lon, &ew, &speed, &course, &day, &mon, &year);
+            pfd.fd = fd;
+            pfd.events = POLLIN;
+            ok = poll(&pfd, 1, -1);
 
-      if(res == 14 && valid == 'A') {
+            if (ok < 0)
+              continue;
 
-	*lat /= 100;
-	*lon /= 100;
+            n = read(fd, &b, 1);
 
-	if(ns == 'S')
-	  *lat = -*lat;
-	
-	if(ew == 'W')
-	  *lon = -*lon;
+            if (n < 0)
+              continue;
 
-	done = 1;
-      }
-    }
-  }
-  if(!done)
-    return(-1);
+            buf[bp++] = b;
+            if (b == '\n')
+              break;
+          }
+
+          if (strncmp("$GPRMC", buf, 6) == 0)
+          {
+
+            if (debug)
+              printf("%s", buf);
+
+            res = sscanf(buf, "$GPRMC,%2d%2d%2d.%3c,%1c,%f,%1c,%f,%1c,%f,%f,%2d%2d%2d", &hour, &min, &sec, foo, &valid,
+                         lat, &ns, lon, &ew, &speed, &course, &day, &mon, &year);
+
+            if (res == 14 && valid == 'A')
+            {
+
+              *lat /= 100;
+              *lon /= 100;
+
+              if (ns == 'S')
+                *lat = -*lat;
+
+              if (ew == 'W')
+                *lon = -*lon;
+
+              done = 1;
+            }
+          }
+        }
+  if (!done)
+    return (-1);
   else
     return 1;
 }
@@ -1139,22 +1253,21 @@ $GPGSA,A,3,04,05,,09,12,,,24,,,,,2.5,1.3,2.1*39
 
 Where:
      GSA      Satellite status
-     A        Auto selection of 2D or 3D fix (M = manual) 
+     A        Auto selection of 2D or 3D fix (M = manual)
      3        3D fix - values include: 1 = no fix
                                        2 = 2D fix
                                        3 = 3D fix
-     04,05... PRNs of satellites used for fix (space for 12) 
-     2.5      PDOP (dilution of precision) 
-     1.3      Horizontal dilution of precision (HDOP) 
+     04,05... PRNs of satellites used for fix (space for 12)
+     2.5      PDOP (dilution of precision)
+     1.3      Horizontal dilution of precision (HDOP)
      2.1      Vertical dilution of precision (VDOP)
      *39      the checksum data, always begins with *
 
 */
 
-
 /*
 
-We get: $GPRMC,080642.000,A,5951.0512,N,01736.8681,E,0.10,345.68,140307,,*0D      
+We get: $GPRMC,080642.000,A,5951.0512,N,01736.8681,E,0.10,345.68,140307,,*0D
 
 $GPRMC,hhmmss.ss,A,llll.ll,a,yyyyy.yy,a,x.x,x.x,ddmmyy,x.x,a*hh
 


### PR DESCRIPTION
No semantic changes to functionality where made here.
Only whitespace, indentation and parenthesis fixes to make the code easier to read.
I used `:%!astyle --mode=c -s2` in vim to autoformat it. 
